### PR TITLE
cosmetic bug: Fix image allign backport

### DIFF
--- a/site/get/stream.md
+++ b/site/get/stream.md
@@ -51,8 +51,8 @@
 
   <h3 id="2025.11">VyOS Stream 2025.11</h3>
 
-* Image: [vyos-2025.11-generic-amd64.iso](https://community-downloads.vyos.dev/stream/2025.11/vyos-2025.11-generic-amd64.iso) ([sig](https://community-downloads.vyos.dev/stream/2025.11/vyos-2025.11-generic-amd64.iso.minisig))
-* Source code tarball: [circinus-2025.11.tar.gz](https://community-downloads.vyos.dev/stream/2025.11/circinus-2025.11.tar.gz) ([sig](https://community-downloads.vyos.dev/stream/2025.11/circinus-2025.11.tar.gz.minisig))
+  * Image: [vyos-2025.11-generic-amd64.iso](https://community-downloads.vyos.dev/stream/2025.11/vyos-2025.11-generic-amd64.iso) ([sig](https://community-downloads.vyos.dev/stream/2025.11/vyos-2025.11-generic-amd64.iso.minisig))
+  * Source code tarball: [circinus-2025.11.tar.gz](https://community-downloads.vyos.dev/stream/2025.11/circinus-2025.11.tar.gz) ([sig](https://community-downloads.vyos.dev/stream/2025.11/circinus-2025.11.tar.gz.minisig))
 
   <h3 id="1.5-2025-Q2">VyOS Stream 1.5-2025-Q2</h3>
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
(cherry picked from commit e8107f90846c7256184983a42a0fc8a3f5f36c66)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): cosmetic bug: Fix image align (backport)

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
