### PR TITLE
Ignore .soupault-cache/ build artifact directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 index.json
+.soupault-cache/


### PR DESCRIPTION
## Summary

- Add `.soupault-cache/` to `.gitignore`.

Soupault 5.x writes an incremental build cache to `.soupault-cache/` in the repo root on every local build. The directory shows up as untracked in `git status` after building, and `gh pr create` warns about it. Treating it the same way `build/*` is already treated.

## Test plan

- [ ] After applying: running `soupault --profile live` (or staging) and then `git status` shows no untracked `.soupault-cache/` entry.

Generated with [Claude Code](https://claude.com/claude-code)
