### PR TITLE
Ignore .soupault-cache/ build artifact directory (production)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 index.json
+.soupault-cache/


### PR DESCRIPTION
## Summary

- Add `.soupault-cache/` to `.gitignore` on the `production` branch.

Same change as #36 (which targets `main`), cherry-picked onto `production` so the production branch also has the ignore entry. Soupault 5.x writes an incremental build cache to `.soupault-cache/` on every local build; treating it the same way `build/*` is already treated.

## Test plan

- [ ] After merge: running `soupault --profile live` and then `git status` on a `production` checkout shows no untracked `.soupault-cache/` entry.

Generated with [Claude Code](https://claude.com/claude-code)
