### PR TITLE
Address Copilot review: preconnect order + staging-gate cookies-policy script

### DIFF
--- a/site/legal/cookies-policy.md
+++ b/site/legal/cookies-policy.md
@@ -4,7 +4,4 @@ This page lists the cookies set by vyos.net. Cookie data is maintained automatic
 
 For the VyOS privacy policy covering all VyOS properties, see [vyos.io/legal/privacy-policy](https://vyos.io/legal/privacy-policy).
 
-<script id="CookieDeclaration"
-        src="https://consent.cookiebot.com/<CBID>/cd.js"
-        type="text/javascript"
-        async></script>
+<div id="cookie-declaration-placeholder"></div>

--- a/soupault.toml
+++ b/soupault.toml
@@ -78,7 +78,22 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <link rel="preconnect" href="https://consent.cookiebot.com" crossorigin />
 """
   selector = "head"
-  action = "append_child"
+  action = "prepend_child"
+  after = "insert-google-tag-manager-head"
+  profile = "live"
+
+# The Cookiebot CookieDeclaration script is injected only on live builds so
+# staging visitors who hit /legal/cookies-policy/ don't leak their IP to
+# consent.cookiebot.com. The markdown source contains a placeholder div
+# (#cookie-declaration-placeholder) that this widget replaces in place.
+[widgets.insert-cookiebot-declaration]
+  widget = "insert_html"
+  page = "legal/cookies-policy.md"
+  html = """
+<script id="CookieDeclaration" src="https://consent.cookiebot.com/<CBID>/cd.js" type="text/javascript" async></script>
+"""
+  selector = "#cookie-declaration-placeholder"
+  action = "replace_element"
   profile = "live"
 
 # Inserts a scary warning banner in preview versions


### PR DESCRIPTION
## Summary

Addresses 2 of 3 inline comments left by `copilot-pull-request-reviewer` on #35. This PR targets the feature branch so the fixes flow through the parent PR.

## Fixes

**1. Preconnect hints now actually beat the GTM fetch (comment on `soupault.toml:81`)**

Previously `insert-preconnect-hints` used `action = "append_child"` on `head`, so the two `<link rel="preconnect">` tags landed *after* the GTM loader snippet that was `prepend_child`-ed to the top. GTM's inline IIFE triggered the fetch to `metrics.vyos.io/gtm.js` before the browser parsed the preconnect tags, so they provided zero benefit.

Switched to `action = "prepend_child"` and added `after = "insert-google-tag-manager-head"` so the widget runs after GTM and its prepend pushes GTM down to position 1. Verified locally: first `rel="preconnect"` now appears at head line 2, GTM's `metrics.vyos.io/gtm.js` at line 8.

**2. Cookiebot `cd.js` no longer ships on staging (comment on `site/legal/cookies-policy.md:10`)**

Previously the `<script id="CookieDeclaration" src="https://consent.cookiebot.com/<CBID>/cd.js">` was embedded directly in the markdown, so a staging visitor who navigated to `/legal/cookies-policy/` would leak their IP to `consent.cookiebot.com`. The parent plan accepted this as a tradeoff (staging is `Disallow: /`), but tightening to defense-in-depth:

- Replaced the inline script in `site/legal/cookies-policy.md` with `<div id="cookie-declaration-placeholder"></div>`.
- Added `[widgets.insert-cookiebot-declaration]` in `soupault.toml` — scoped to `legal/cookies-policy.md`, gated on `profile = "live"`, uses `action = "replace_element"` on the placeholder. The script only appears on the live build.

Verified: staging build of `build/legal/cookies-policy/index.html` now contains zero references to `consent.cookiebot.com`; live build contains the script exactly once.

## The third comment (CBID placeholder)

Not fixed here — tracked as a checkbox in the parent PR's Prerequisites ("Cookiebot CBID substituted into `site/legal/cookies-policy.md`"). Will be substituted before `main` → `production` merge. A thread reply will be added on #35 pointing at that prerequisite.

## Test plan

- [x] `soupault --profile staging && make css` — `build/legal/cookies-policy/index.html` contains no `consent.cookiebot.com`; primary pages still tracker-free.
- [x] `soupault --profile live && make css` — `build/index.html` first preconnect line precedes GTM's `metrics.vyos.io/gtm.js`; `build/legal/cookies-policy/index.html` contains `id="CookieDeclaration"` exactly once.

Generated with [Claude Code](https://claude.com/claude-code)
