### PR TITLE
Production deploy: 1.5.0 status + Cookiebot direct loader + Mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,7 @@
+# Mergify configuration — manual commands only, no automated rules.
+# Available commands (post in a PR comment):
+#   @Mergifyio merge        — merge the PR
+#   @Mergifyio rebase       — rebase the branch on the base branch
+#   @Mergifyio update       — update the branch (merge base into it)
+#   @Mergifyio backport <branch> — backport to another branch
+pull_request_rules: []

--- a/release-status.toml
+++ b/release-status.toml
@@ -6,4 +6,10 @@
 
   notes = "Maintenance release"
 
+[release.circinus]
+  latest = "1.5.0"
 
+  security_advisory = [
+  ]
+
+  notes = "GA release"

--- a/soupault.toml
+++ b/soupault.toml
@@ -42,7 +42,17 @@
   selector = "main"
   action = "insert_before"
 
-# Inserts the banner in main page only
+# Cookiebot consent banner — loaded before GTM so consent state is set
+# before any tracking tags fire.
+[widgets.insert-cookiebot-loader]
+  widget = "insert_html"
+  html = """
+<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="932cb8b9-5141-4dc9-9018-21fc31a0586f" data-blockingmode="auto" type="text/javascript" async></script>
+"""
+  selector = "head"
+  action = "prepend_child"
+  after = "insert-google-tag-manager-head"
+  profile = "live"
 
 [widgets.insert-google-tag-manager-head]
   widget = "insert_html"


### PR DESCRIPTION
## Summary

Promotes `main` to `production` (vyos.net live site).

**Delivers:**

- **#41** — Add VyOS 1.5.0 to release status
- **#42** — Load Cookiebot `uc.js` directly in `<head>` before GTM (fixes missing consent banner on vyos.net)
- **#43** — Add Mergify configuration to enable PR commands

## Post-merge verification

- [x] Cookiebot consent banner appears on `https://vyos.net/` in fresh incognito window
- [x] `https://vyos.net/status/` shows VyOS 1.5.0 in the release status table

🤖 Generated by [robots](https://vyos.io)