### PR TITLE
fix: remove async from Cookiebot loader (GDPR consent-before-GTM)

### DIFF
--- a/soupault.toml
+++ b/soupault.toml
@@ -42,12 +42,18 @@
   selector = "main"
   action = "insert_before"
 
-# Cookiebot consent banner — loaded before GTM so consent state is set
-# before any tracking tags fire.
+# Cookiebot consent banner — must be synchronous (no `async`) so the browser
+# blocks on it before parsing GTM's inline bootstrap script. With `async`,
+# the GTM snippet would execute before Cookiebot sets consent state.
+#
+# `after = "insert-google-tag-manager-head"` controls soupault execution order,
+# not DOM order: GTM widget runs first (prepends GTM to <head>), then this
+# widget runs and prepends Cookiebot — so Cookiebot ends up before GTM in the
+# final HTML.
 [widgets.insert-cookiebot-loader]
   widget = "insert_html"
   html = """
-<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="932cb8b9-5141-4dc9-9018-21fc31a0586f" data-blockingmode="auto" type="text/javascript" async></script>
+<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="932cb8b9-5141-4dc9-9018-21fc31a0586f" data-blockingmode="auto" type="text/javascript"></script>
 """
   selector = "head"
   action = "prepend_child"


### PR DESCRIPTION
## Summary

- Removes `async` from the Cookiebot script tag in `soupault.toml`
- With `async`, the browser downloads Cookiebot in parallel and immediately continues parsing HTML — GTM's inline bootstrap script fires before Cookiebot has set consent state
- Without `async`, Cookiebot is render-blocking: the browser stops, executes it, then continues to GTM

Also expands the comment to explain the counter-intuitive `after` + `prepend_child` ordering: `after = "insert-google-tag-manager-head"` controls soupault widget execution order, not DOM position — GTM widget runs first (prepends GTM to `<head>`), then Cookiebot widget prepends, ending up before GTM in final HTML.

## Test plan
- [ ] Build locally and inspect generated HTML — Cookiebot script should appear before GTM script in `<head>`
- [ ] Verify Cookiebot banner appears before any GTM tags fire on page load

🤖 Generated by [robots](https://vyos.io)