### PR TITLE
build: profile-gate Amplify builds; add PR check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           wget -q https://github.com/PataphysicalSociety/soupault/releases/download/4.10.0/soupault-4.10.0-linux-x86_64.tar.gz
           tar xf soupault-4.10.0-linux-x86_64.tar.gz
-          sudo mv soupault-4.10.0-linux-x86_64/soupault /usr/local/bin/
+          sudo mv soupault-4.10.0-linux-x86_64/soupault /usr/bin/
 
       - name: Build (staging profile)
         run: SOUPAULT_OPTS="--profile staging" make all

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,27 @@
+name: PR build check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cmark
+        run: sudo apt-get install -y cmark
+
+      - name: Install Dart Sass
+        run: npm install -g sass@1.32.8
+
+      - name: Install soupault
+        run: |
+          wget -q https://github.com/PataphysicalSociety/soupault/releases/download/4.10.0/soupault-4.10.0-linux-x86_64.tar.gz
+          tar xf soupault-4.10.0-linux-x86_64.tar.gz
+          sudo mv soupault-4.10.0-linux-x86_64/soupault /usr/local/bin/
+
+      - name: Build (staging profile)
+        run: SOUPAULT_OPTS="--profile staging" make all

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cmark
-        run: sudo apt-get install -y cmark
+        run: sudo apt-get update && sudo apt-get install -y cmark
 
       - name: Install Dart Sass
         run: npm install -g sass@1.32.8

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/*
 index.json
 .soupault-cache/
+.worktrees/

--- a/amplify.yml
+++ b/amplify.yml
@@ -16,7 +16,7 @@ applications:
         build:
           commands:
             - source .venv/bin/activate
-            - '[ "$AWS_BRANCH" = "production" ] && export SOUPAULT_OPTS="--profile live" || export SOUPAULT_OPTS="--profile staging"'
+            - 'if [ "$AWS_BRANCH" = "production" ]; then export SOUPAULT_OPTS="--profile live"; else export SOUPAULT_OPTS="--profile staging"; fi'
             - make all
       artifacts:
         baseDirectory: /build

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,27 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        preBuild:
+          commands:
+            - export GH_ACCESS_TOKEN=$(aws ssm get-parameter --name /amplify/shared/d224keb5xu0spt/GH_ACCESS_TOKEN --query Parameter.Value --output text --with-decryption)
+            - sudo yum install -y https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/c/cmark-0.29.0-4.el9.x86_64.rpm
+            - npm install -g sass@1.32.8
+            - python3 -m venv .venv
+            - source .venv/bin/activate
+            - pip install pygithub jinja2
+            - wget https://github.com/PataphysicalSociety/soupault/releases/download/4.10.0/soupault-4.10.0-linux-x86_64.tar.gz
+            - tar xvf soupault-4.10.0-linux-x86_64.tar.gz
+            - mv -v ./soupault-4.10.0-linux-x86_64/soupault /usr/bin/
+        build:
+          commands:
+            - source .venv/bin/activate
+            - '[ "$AWS_BRANCH" = "production" ] && export SOUPAULT_OPTS="--profile live" || export SOUPAULT_OPTS="--profile staging"'
+            - make all
+      artifacts:
+        baseDirectory: /build
+        files:
+          - '**/*'
+      cache:
+        paths:
+            - node_modules/**/*


### PR DESCRIPTION
## Summary

- Adds \`amplify.yml\` to override the Amplify console build spec and select soupault profile by branch: \`main\` → \`--profile staging\`, \`production\` → \`--profile live\`. Fixes live widgets (GTM, Cookiebot, preconnects) appearing on staging.vyos.net.
- Adds \`.github/workflows/pr-check.yml\`: builds with \`--profile staging\` on any PR targeting \`main\`, giving a pass/fail check before merge. Runs locally in the Actions runner — no Amplify branch config needed.

## Verification (post-merge to main)

- [ ] Amplify rebuilds staging → \`curl -s https://staging.vyos.net/ | grep -c "GTM-T5VQHRT\\|consent\\.cookiebot\\.com\\|metrics\\.vyos\\.io"\` → \`0\`
- [ ] Open any test PR targeting \`main\` → "PR build check / build" check appears and passes
- [ ] After next \`main → production\` merge → \`vyos.net\` page source contains \`GTM-T5VQHRT\`, \`consent.cookiebot.com\`, \`metrics.vyos.io\`

🤖 Generated by [robots](https://vyos.io)