### PR TITLE
build: address amplify.yml review feedback

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ applications:
       phases:
         preBuild:
           commands:
-            - export GH_ACCESS_TOKEN=$(aws ssm get-parameter --name /amplify/shared/d224keb5xu0spt/GH_ACCESS_TOKEN --query Parameter.Value --output text --with-decryption)
+            - 'if [ "$AWS_BRANCH" = "production" ]; then export GH_ACCESS_TOKEN=$(aws ssm get-parameter --name /amplify/shared/d224keb5xu0spt/GH_ACCESS_TOKEN --query Parameter.Value --output text --with-decryption); else unset GH_ACCESS_TOKEN; fi'
             - sudo yum install -y https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/c/cmark-0.29.0-4.el9.x86_64.rpm
             - npm install -g sass@1.32.8
             - python3 -m venv .venv
@@ -12,7 +12,7 @@ applications:
             - pip install pygithub jinja2
             - wget https://github.com/PataphysicalSociety/soupault/releases/download/4.10.0/soupault-4.10.0-linux-x86_64.tar.gz
             - tar xvf soupault-4.10.0-linux-x86_64.tar.gz
-            - mv -v ./soupault-4.10.0-linux-x86_64/soupault /usr/bin/
+            - sudo mv -v ./soupault-4.10.0-linux-x86_64/soupault /usr/bin/
         build:
           commands:
             - source .venv/bin/activate


### PR DESCRIPTION
## Summary

Follow-up to #46 addressing valid Copilot review items.

**Fixed:**
- Gate `GH_ACCESS_TOKEN` SSM fetch on `$AWS_BRANCH = production` — staging builds no longer depend on that secret. If SSM is unavailable, staging continues to work.
- Add `sudo` to the soupault `mv` command — defensive fix for non-root build images.

**Not implemented (with reasoning):**

- **`yum install -y cmark`** — the specific EPEL9 RPM URL is copied from the existing working console build spec. `cmark` is not in the default Amazon Linux yum repos; switching to bare `yum install` would break builds.

- **SHA256 checksums for soupault tarball** — both suggestions included literal placeholder values (`REPLACE_WITH_OFFICIAL_SHA256_FOR_SOUPAULT_4.10.0_LINUX_X86_64_TARBALL`) that would fail the build as written. The pattern (downloading from official GitHub releases) mirrors the existing console spec.

- **`baseDirectory: build` (no leading slash)** — `/build` is the value in the existing working console build spec. Amplify treats it as project-root-relative. Confirmed by internal code review before this PR was opened.

## Merge order

Merge #46 first, then this PR.

🤖 Generated by [robots](https://vyos.io)