### PR TITLE
build: quote SSM command substitution in amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ applications:
       phases:
         preBuild:
           commands:
-            - export GH_ACCESS_TOKEN=$(aws ssm get-parameter --name /amplify/shared/d224keb5xu0spt/GH_ACCESS_TOKEN --query Parameter.Value --output text --with-decryption)
+            - 'if [ "$AWS_BRANCH" = "production" ]; then export GH_ACCESS_TOKEN=$(aws ssm get-parameter --name /amplify/shared/d224keb5xu0spt/GH_ACCESS_TOKEN --query Parameter.Value --output text --with-decryption); else unset GH_ACCESS_TOKEN; fi'
             - sudo yum install -y https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/c/cmark-0.29.0-4.el9.x86_64.rpm
             - npm install -g sass@1.32.8
             - python3 -m venv .venv
@@ -12,7 +12,7 @@ applications:
             - pip install pygithub jinja2
             - wget https://github.com/PataphysicalSociety/soupault/releases/download/4.10.0/soupault-4.10.0-linux-x86_64.tar.gz
             - tar xvf soupault-4.10.0-linux-x86_64.tar.gz
-            - mv -v ./soupault-4.10.0-linux-x86_64/soupault /usr/bin/
+            - sudo mv -v ./soupault-4.10.0-linux-x86_64/soupault /usr/bin/
         build:
           commands:
             - source .venv/bin/activate

--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ applications:
       phases:
         preBuild:
           commands:
-            - 'if [ "$AWS_BRANCH" = "production" ]; then export GH_ACCESS_TOKEN=$(aws ssm get-parameter --name /amplify/shared/d224keb5xu0spt/GH_ACCESS_TOKEN --query Parameter.Value --output text --with-decryption); else unset GH_ACCESS_TOKEN; fi'
+            - 'if [ "$AWS_BRANCH" = "production" ]; then export GH_ACCESS_TOKEN="$(aws ssm get-parameter --name /amplify/shared/d224keb5xu0spt/GH_ACCESS_TOKEN --query Parameter.Value --output text --with-decryption)"; else unset GH_ACCESS_TOKEN; fi'
             - sudo yum install -y https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/c/cmark-0.29.0-4.el9.x86_64.rpm
             - npm install -g sass@1.32.8
             - python3 -m venv .venv


### PR DESCRIPTION
## Summary

Supersedes #47. Includes all changes from that PR plus this fix.

Quotes the `$(aws ssm ...)` command substitution in the `GH_ACCESS_TOKEN` export to prevent word-splitting if the token value ever contains IFS characters.

```diff
- export GH_ACCESS_TOKEN=$(aws ssm get-parameter ...)
+ export GH_ACCESS_TOKEN="$(aws ssm get-parameter ...)"
```

**Merge order:** Close #47, merge this one instead.

🤖 Generated by [robots](https://vyos.io)