### PR TITLE
feat: generate sitemap.xml on live builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,8 @@ css:
 	sass -I sass/ sass/main.sass > build/main.css
 
 all: site css
+
+.PHONY: live
+live: css
+	soupault --profile live ${SOUPAULT_OPTS}
+	python3 scripts/generate-sitemap.py

--- a/amplify.yml
+++ b/amplify.yml
@@ -18,6 +18,7 @@ applications:
             - source .venv/bin/activate
             - 'if [ "$AWS_BRANCH" = "production" ]; then export SOUPAULT_OPTS="--profile live"; else export SOUPAULT_OPTS="--profile staging"; fi'
             - make all
+            - 'if [ "$AWS_BRANCH" = "production" ]; then python3 scripts/generate-sitemap.py; fi'
       artifacts:
         baseDirectory: /build
         files:

--- a/scripts/generate-sitemap.py
+++ b/scripts/generate-sitemap.py
@@ -46,3 +46,14 @@ def derive_url(filepath, site_dir):
     else:
         url_path = "/" + "/".join(path_parts) + "/"
     return BASE_URL + url_path
+
+
+def get_heuristics(url_path):
+    """Return (changefreq, priority) tuple for a URL path string."""
+    if url_path in OVERRIDES:
+        o = OVERRIDES[url_path]
+        return o["changefreq"], o["priority"]
+    depth = len([s for s in url_path.split("/") if s])
+    idx = min(depth, 2)
+    d = DEPTH_DEFAULTS[idx]
+    return d["changefreq"], d["priority"]

--- a/scripts/generate-sitemap.py
+++ b/scripts/generate-sitemap.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import os
+import sys
+import datetime
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+BASE_URL = "https://vyos.net"
+
+ASSET_DIRS = {"img", "js", "favicon"}
+
+OVERRIDES = {
+    "/get/": {"changefreq": "daily", "priority": "0.8"},
+    "/get/nightly-builds/": {"changefreq": "daily", "priority": "0.5"},
+}
+
+DEPTH_DEFAULTS = [
+    {"changefreq": "daily",   "priority": "1.0"},   # depth 0
+    {"changefreq": "weekly",  "priority": "0.8"},   # depth 1
+    {"changefreq": "monthly", "priority": "0.5"},   # depth 2+
+]
+
+
+def find_pages(site_dir):
+    """Return list of absolute paths to routable page source files."""
+    pages = []
+    for dirpath, dirnames, filenames in os.walk(site_dir):
+        dirnames[:] = [d for d in dirnames if d not in ASSET_DIRS]
+        for fname in filenames:
+            if fname.endswith((".md", ".html")):
+                pages.append(os.path.join(dirpath, fname))
+    return pages

--- a/scripts/generate-sitemap.py
+++ b/scripts/generate-sitemap.py
@@ -57,3 +57,67 @@ def get_heuristics(url_path):
     idx = min(depth, 2)
     d = DEPTH_DEFAULTS[idx]
     return d["changefreq"], d["priority"]
+
+
+def generate_sitemap(site_dir, build_dir, today=None):
+    """Discover pages in site_dir and write build_dir/sitemap.xml."""
+    if today is None:
+        today = datetime.date.today().isoformat()
+
+    if not os.path.isdir(site_dir):
+        print(f"Error: site directory not found: {site_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    pages = find_pages(site_dir)
+    if not pages:
+        print("Error: no routable pages discovered in site/", file=sys.stderr)
+        sys.exit(1)
+
+    # Derive URLs, detect duplicates
+    url_to_source = {}
+    for page in pages:
+        url = derive_url(page, site_dir)
+        if url in url_to_source:
+            print(
+                f"Error: duplicate URL {url} from:\n"
+                f"  {url_to_source[url]}\n"
+                f"  {page}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        url_to_source[url] = page
+
+    # Build XML tree
+    urlset = ET.Element("urlset")
+    urlset.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")
+
+    for url in sorted(url_to_source):
+        url_path = url[len(BASE_URL):]
+        changefreq, priority = get_heuristics(url_path)
+        url_el = ET.SubElement(urlset, "url")
+        ET.SubElement(url_el, "loc").text = url
+        ET.SubElement(url_el, "lastmod").text = today
+        ET.SubElement(url_el, "changefreq").text = changefreq
+        ET.SubElement(url_el, "priority").text = priority
+
+    # Pretty-print via minidom
+    raw = ET.tostring(urlset, encoding="unicode")
+    dom = minidom.parseString(raw)
+    pretty = dom.toprettyxml(indent="  ", encoding="UTF-8")
+
+    out_path = os.path.join(build_dir, "sitemap.xml")
+    with open(out_path, "wb") as f:
+        f.write(pretty)
+    print(f"Wrote {out_path}")
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.dirname(script_dir)
+    site_dir = os.path.join(repo_root, "site")
+    build_dir = os.path.join(repo_root, "build")
+    generate_sitemap(site_dir, build_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-sitemap.py
+++ b/scripts/generate-sitemap.py
@@ -106,6 +106,7 @@ def generate_sitemap(site_dir, build_dir, today=None):
     pretty = dom.toprettyxml(indent="  ", encoding="UTF-8")
 
     out_path = os.path.join(build_dir, "sitemap.xml")
+    os.makedirs(build_dir, exist_ok=True)
     with open(out_path, "wb") as f:
         f.write(pretty)
     print(f"Wrote {out_path}")

--- a/scripts/generate-sitemap.py
+++ b/scripts/generate-sitemap.py
@@ -30,3 +30,19 @@ def find_pages(site_dir):
             if fname.endswith((".md", ".html")):
                 pages.append(os.path.join(dirpath, fname))
     return pages
+
+
+def derive_url(filepath, site_dir):
+    """Derive canonical URL from a source file path relative to site_dir."""
+    rel = os.path.relpath(filepath, site_dir)
+    parts = rel.replace(os.sep, "/").split("/")
+    stem = os.path.splitext(parts[-1])[0]
+    if stem == "index":
+        path_parts = parts[:-1]
+    else:
+        path_parts = parts[:-1] + [stem]
+    if not path_parts:
+        url_path = "/"
+    else:
+        url_path = "/" + "/".join(path_parts) + "/"
+    return BASE_URL + url_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,8 @@ def derive_url(sitemap_module):
 @pytest.fixture(scope="session")
 def get_heuristics(sitemap_module):
     return sitemap_module.get_heuristics
+
+
+@pytest.fixture(scope="session")
+def generate_sitemap(sitemap_module):
+    return sitemap_module.generate_sitemap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,24 @@
 import importlib.util
 import os
-import sys
+import pytest
 
-def load_generate_sitemap():
+
+def _load_generate_sitemap():
     script_path = os.path.join(
         os.path.dirname(__file__), "..", "scripts", "generate-sitemap.py"
     )
     spec = importlib.util.spec_from_file_location("generate_sitemap", script_path)
     mod = importlib.util.module_from_spec(spec)
+    # Load the module from its file path (required because filename contains a hyphen)
     spec.loader.exec_module(mod)
     return mod
+
+
+@pytest.fixture(scope="session")
+def sitemap_module():
+    return _load_generate_sitemap()
+
+
+@pytest.fixture(scope="session")
+def find_pages(sitemap_module):
+    return sitemap_module.find_pages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import importlib.util
+import os
+import sys
+
+def load_generate_sitemap():
+    script_path = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "generate-sitemap.py"
+    )
+    spec = importlib.util.spec_from_file_location("generate_sitemap", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,3 +27,8 @@ def find_pages(sitemap_module):
 @pytest.fixture(scope="session")
 def derive_url(sitemap_module):
     return sitemap_module.derive_url
+
+
+@pytest.fixture(scope="session")
+def get_heuristics(sitemap_module):
+    return sitemap_module.get_heuristics

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,8 @@ def sitemap_module():
 @pytest.fixture(scope="session")
 def find_pages(sitemap_module):
     return sitemap_module.find_pages
+
+
+@pytest.fixture(scope="session")
+def derive_url(sitemap_module):
+    return sitemap_module.derive_url

--- a/tests/test_generate_sitemap.py
+++ b/tests/test_generate_sitemap.py
@@ -1,5 +1,8 @@
 import os
+import xml.etree.ElementTree as ET
 import pytest
+
+NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
 
 
 def make_site(tmp_path, files):
@@ -109,3 +112,178 @@ def test_get_heuristics_depth3_uses_depth2_default(get_heuristics):
     changefreq, priority = get_heuristics("/a/b/c/")
     assert changefreq == "monthly"
     assert priority == "0.5"
+
+
+def make_full_site(tmp_path):
+    """Create a site/ tree matching the current vyos.net structure."""
+    files = [
+        "index.html",
+        "about/index.md",
+        "about/upstream-projects.md",
+        "contribute/index.md",
+        "get/index.md",
+        "get/contributor-subscriptions.md",
+        "get/nightly-builds.md",
+        "get/stream.md",
+        "status.md",
+        "legal/cookies-policy.md",
+        "img/logo.svg",
+        "js/app.js",
+    ]
+    return make_site(tmp_path / "site", files)
+
+
+def test_generate_sitemap_produces_xml(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    out = build / "sitemap.xml"
+    assert out.exists()
+
+
+def test_generate_sitemap_well_formed(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    ET.parse(str(build / "sitemap.xml"))  # raises if not well-formed
+
+
+def test_generate_sitemap_namespace(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    assert root.tag == f"{{{NS}}}urlset"
+
+
+def test_generate_sitemap_url_count(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    urls = root.findall(f"{{{NS}}}url")
+    assert len(urls) == 10
+
+
+def test_generate_sitemap_all_fields_present(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    for url_el in root.findall(f"{{{NS}}}url"):
+        assert url_el.find(f"{{{NS}}}loc") is not None
+        assert url_el.find(f"{{{NS}}}lastmod") is not None
+        assert url_el.find(f"{{{NS}}}changefreq") is not None
+        assert url_el.find(f"{{{NS}}}priority") is not None
+
+
+def test_generate_sitemap_lastmod_is_today(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    for url_el in root.findall(f"{{{NS}}}url"):
+        assert url_el.find(f"{{{NS}}}lastmod").text == "2026-04-19"
+
+
+def test_generate_sitemap_urls_sorted(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    locs = [el.find(f"{{{NS}}}loc").text for el in root.findall(f"{{{NS}}}url")]
+    assert locs == sorted(locs)
+
+
+def test_generate_sitemap_no_duplicate_locs(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    locs = [el.find(f"{{{NS}}}loc").text for el in root.findall(f"{{{NS}}}url")]
+    assert len(locs) == len(set(locs))
+
+
+def test_generate_sitemap_root_heuristics(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    root_url = next(
+        el for el in root.findall(f"{{{NS}}}url")
+        if el.find(f"{{{NS}}}loc").text == "https://vyos.net/"
+    )
+    assert root_url.find(f"{{{NS}}}priority").text == "1.0"
+    assert root_url.find(f"{{{NS}}}changefreq").text == "daily"
+
+
+def test_generate_sitemap_get_override(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    get_url = next(
+        el for el in root.findall(f"{{{NS}}}url")
+        if el.find(f"{{{NS}}}loc").text == "https://vyos.net/get/"
+    )
+    assert get_url.find(f"{{{NS}}}changefreq").text == "daily"
+
+
+def test_generate_sitemap_nightly_builds_override(tmp_path, generate_sitemap):
+    site = make_full_site(tmp_path)
+    build = tmp_path / "build"
+    build.mkdir()
+    generate_sitemap(str(site), str(build), today="2026-04-19")
+    tree = ET.parse(str(build / "sitemap.xml"))
+    root = tree.getroot()
+    nb_url = next(
+        el for el in root.findall(f"{{{NS}}}url")
+        if el.find(f"{{{NS}}}loc").text == "https://vyos.net/get/nightly-builds/"
+    )
+    assert nb_url.find(f"{{{NS}}}changefreq").text == "daily"
+
+
+def test_generate_sitemap_error_on_missing_site(tmp_path, generate_sitemap):
+    build = tmp_path / "build"
+    build.mkdir()
+    with pytest.raises(SystemExit) as exc:
+        generate_sitemap(str(tmp_path / "nonexistent"), str(build), today="2026-04-19")
+    assert exc.value.code == 1
+
+
+def test_generate_sitemap_error_on_zero_pages(tmp_path, generate_sitemap):
+    site = tmp_path / "site"
+    site.mkdir()
+    build = tmp_path / "build"
+    build.mkdir()
+    with pytest.raises(SystemExit) as exc:
+        generate_sitemap(str(site), str(build), today="2026-04-19")
+    assert exc.value.code == 1
+
+
+def test_generate_sitemap_error_on_duplicate_urls(tmp_path, generate_sitemap):
+    # foo.md and foo.html at the same path both derive to /foo/
+    site = make_site(tmp_path / "site", ["foo.md", "foo.html"])
+    build = tmp_path / "build"
+    build.mkdir()
+    with pytest.raises(SystemExit) as exc:
+        generate_sitemap(str(site), str(build), today="2026-04-19")
+    assert exc.value.code == 1

--- a/tests/test_generate_sitemap.py
+++ b/tests/test_generate_sitemap.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+from conftest import load_generate_sitemap
+
+mod = load_generate_sitemap()
+find_pages = mod.find_pages
+
+
+def make_site(tmp_path, files):
+    """Create a fake site/ tree. files is a list of relative paths."""
+    for rel in files:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("")
+    return tmp_path
+
+
+def test_find_pages_returns_md_and_html(tmp_path):
+    site = make_site(tmp_path, ["index.html", "about/index.md", "status.md"])
+    result = find_pages(str(site))
+    names = {os.path.basename(p) for p in result}
+    assert names == {"index.html", "index.md", "status.md"}
+
+
+def test_find_pages_excludes_img_dir(tmp_path):
+    site = make_site(tmp_path, ["index.html", "img/logo.svg", "img/favicon/icon.png"])
+    result = find_pages(str(site))
+    assert all("img" not in p for p in result)
+    assert len(result) == 1
+
+
+def test_find_pages_excludes_js_dir(tmp_path):
+    site = make_site(tmp_path, ["index.html", "js/app.js"])
+    result = find_pages(str(site))
+    assert all("js" not in p.split(os.sep) for p in result)
+    assert len(result) == 1
+
+
+def test_find_pages_excludes_favicon_dir(tmp_path):
+    site = make_site(tmp_path, ["index.html", "img/favicon/icon.ico"])
+    result = find_pages(str(site))
+    assert len(result) == 1
+
+
+def test_find_pages_ignores_non_page_extensions(tmp_path):
+    site = make_site(tmp_path, ["index.html", "main.css", "data.toml"])
+    result = find_pages(str(site))
+    assert len(result) == 1
+    assert result[0].endswith("index.html")

--- a/tests/test_generate_sitemap.py
+++ b/tests/test_generate_sitemap.py
@@ -73,3 +73,39 @@ def test_derive_url_nested_md(tmp_path, derive_url):
     site = str(tmp_path)
     filepath = os.path.join(site, "legal", "cookies-policy.md")
     assert derive_url(filepath, site) == "https://vyos.net/legal/cookies-policy/"
+
+
+def test_get_heuristics_root(get_heuristics):
+    changefreq, priority = get_heuristics("/")
+    assert changefreq == "daily"
+    assert priority == "1.0"
+
+
+def test_get_heuristics_depth1(get_heuristics):
+    changefreq, priority = get_heuristics("/about/")
+    assert changefreq == "weekly"
+    assert priority == "0.8"
+
+
+def test_get_heuristics_depth2_default(get_heuristics):
+    changefreq, priority = get_heuristics("/legal/cookies-policy/")
+    assert changefreq == "monthly"
+    assert priority == "0.5"
+
+
+def test_get_heuristics_get_override(get_heuristics):
+    changefreq, priority = get_heuristics("/get/")
+    assert changefreq == "daily"
+    assert priority == "0.8"
+
+
+def test_get_heuristics_nightly_builds_override(get_heuristics):
+    changefreq, priority = get_heuristics("/get/nightly-builds/")
+    assert changefreq == "daily"
+    assert priority == "0.5"
+
+
+def test_get_heuristics_depth3_uses_depth2_default(get_heuristics):
+    changefreq, priority = get_heuristics("/a/b/c/")
+    assert changefreq == "monthly"
+    assert priority == "0.5"

--- a/tests/test_generate_sitemap.py
+++ b/tests/test_generate_sitemap.py
@@ -1,9 +1,5 @@
 import os
 import pytest
-from conftest import load_generate_sitemap
-
-mod = load_generate_sitemap()
-find_pages = mod.find_pages
 
 
 def make_site(tmp_path, files):
@@ -15,34 +11,34 @@ def make_site(tmp_path, files):
     return tmp_path
 
 
-def test_find_pages_returns_md_and_html(tmp_path):
+def test_find_pages_returns_md_and_html(tmp_path, find_pages):
     site = make_site(tmp_path, ["index.html", "about/index.md", "status.md"])
     result = find_pages(str(site))
     names = {os.path.basename(p) for p in result}
     assert names == {"index.html", "index.md", "status.md"}
 
 
-def test_find_pages_excludes_img_dir(tmp_path):
+def test_find_pages_excludes_img_dir(tmp_path, find_pages):
     site = make_site(tmp_path, ["index.html", "img/logo.svg", "img/favicon/icon.png"])
     result = find_pages(str(site))
-    assert all("img" not in p for p in result)
+    assert all("img" not in p.split(os.sep) for p in result)
     assert len(result) == 1
 
 
-def test_find_pages_excludes_js_dir(tmp_path):
+def test_find_pages_excludes_js_dir(tmp_path, find_pages):
     site = make_site(tmp_path, ["index.html", "js/app.js"])
     result = find_pages(str(site))
     assert all("js" not in p.split(os.sep) for p in result)
     assert len(result) == 1
 
 
-def test_find_pages_excludes_favicon_dir(tmp_path):
+def test_find_pages_excludes_favicon_dir(tmp_path, find_pages):
     site = make_site(tmp_path, ["index.html", "img/favicon/icon.ico"])
     result = find_pages(str(site))
     assert len(result) == 1
 
 
-def test_find_pages_ignores_non_page_extensions(tmp_path):
+def test_find_pages_ignores_non_page_extensions(tmp_path, find_pages):
     site = make_site(tmp_path, ["index.html", "main.css", "data.toml"])
     result = find_pages(str(site))
     assert len(result) == 1

--- a/tests/test_generate_sitemap.py
+++ b/tests/test_generate_sitemap.py
@@ -43,3 +43,33 @@ def test_find_pages_ignores_non_page_extensions(tmp_path, find_pages):
     result = find_pages(str(site))
     assert len(result) == 1
     assert result[0].endswith("index.html")
+
+
+def test_derive_url_root_index(tmp_path, derive_url):
+    site = str(tmp_path)
+    filepath = os.path.join(site, "index.html")
+    assert derive_url(filepath, site) == "https://vyos.net/"
+
+
+def test_derive_url_subdir_index(tmp_path, derive_url):
+    site = str(tmp_path)
+    filepath = os.path.join(site, "about", "index.md")
+    assert derive_url(filepath, site) == "https://vyos.net/about/"
+
+
+def test_derive_url_regular_md(tmp_path, derive_url):
+    site = str(tmp_path)
+    filepath = os.path.join(site, "about", "upstream-projects.md")
+    assert derive_url(filepath, site) == "https://vyos.net/about/upstream-projects/"
+
+
+def test_derive_url_top_level_md(tmp_path, derive_url):
+    site = str(tmp_path)
+    filepath = os.path.join(site, "status.md")
+    assert derive_url(filepath, site) == "https://vyos.net/status/"
+
+
+def test_derive_url_nested_md(tmp_path, derive_url):
+    site = str(tmp_path)
+    filepath = os.path.join(site, "legal", "cookies-policy.md")
+    assert derive_url(filepath, site) == "https://vyos.net/legal/cookies-policy/"


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-sitemap.py` — walks `site/`, derives canonical URLs, applies depth-based heuristics with per-path overrides for `/get/` and `/get/nightly-builds/`, writes sorted pretty-printed `build/sitemap.xml`
- Adds `make live` convenience target for local live builds (`soupault --profile live` + sitemap script)
- Wires sitemap generation into `amplify.yml` production branch builds via a conditional shell step after `make all`

## Details

- Page discovery reads `site/` (not `build/`), excludes `img/`, `js/`, `favicon/` dirs
- Heuristics: depth 0 → daily/1.0, depth 1 → weekly/0.8, depth 2+ → monthly/0.5; `/get/` and `/get/nightly-builds/` override to daily
- `lastmod` = build date (intentional: represents last regeneration, not per-page modification)
- Staging builds do not get a sitemap (`make all` does not call the script)
- Python 3.6+, stdlib only

## Test Plan

- [ ] 30 unit + integration tests pass (`pytest tests/ -v`)
- [ ] `python3 scripts/generate-sitemap.py` produces `build/sitemap.xml` with 10 URLs
- [ ] `python3 -c "import xml.etree.ElementTree as ET; ET.parse('build/sitemap.xml'); print('OK')"` outputs `OK`
- [ ] URLs in `build/sitemap.xml` are sorted alphabetically
- [ ] `https://vyos.net/get/` has `changefreq=daily` (override applied)
- [ ] `make all` does not produce `build/sitemap.xml` on a clean build

🤖 Generated by [robots](https://vyos.io)