### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ VyOS community website (community.vyos.net). A static site built by the [soupaul
 - Soupault plugins under `plugins/` (Lua).
 - AWS Amplify deploy spec: `amplify.yml`.
 - `release-status.toml` for the per-train release banner data.
-- `mergify.yml` present (single-rule conflicts label).
+- `.mergify.yml` present (commands-only; no automated rules).
 
 ## Build / test / run
 
@@ -45,7 +45,7 @@ Static site, independent of the VyOS image build. Sibling corporate web properti
 
 - Commit / PR title format: `component: T12345: description` (Phorge task ID mandatory). Enforced by `vyos/.github` reusable workflows where consumed.
 - **Branch model differs:** `main` is the staging branch (auto-deployed to staging.vyos.net); `production` is the production branch.
-- `mergify.yml` adds a `conflicts` label to conflicting PRs (byte-identical to other VyOS repos with this file).
+- `.mergify.yml` provides Mergify commands (`merge`, `rebase`, `update`, `backport`) but has no automated PR rules.
 
 ## Mirror relationship
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+## Project purpose
+
+VyOS community website (community.vyos.net). A static site built by the [soupault](https://soupault.app) static-site generator from HTML pages plus SASS-built CSS. Deployed via AWS Amplify (`amplify.yml` present).
+
+## Tech stack
+
+- Static-site generator: soupault (OCaml).
+- HTML templates under `templates/`, content under `site/`.
+- Sass for stylesheets (`sass/main.sass` → `build/main.css`).
+- Soupault plugins under `plugins/` (Lua).
+- AWS Amplify deploy spec: `amplify.yml`.
+- `release-status.toml` for the per-train release banner data.
+- `mergify.yml` present (single-rule conflicts label).
+
+## Build / test / run
+
+```
+# Site
+soupault                    # → build/
+# CSS
+sass -I sass/ sass/main.sass > build/main.css
+# Combined
+make all
+```
+
+## Repository layout
+
+- `templates/` — page skeletons including `main.html`; soupault inserts page content into `div#content`.
+- `site/` — actual page content (Markdown + HTML).
+- `sass/` — SASS sources.
+- `fonts/` — static assets.
+- `plugins/` — soupault Lua plugins.
+- `scripts/` — helper scripts.
+- `soupault.toml` — site config; markdown extensions, strict mode, etc.
+- `amplify.yml` — Amplify build pipeline (likely calls `make all`).
+- `release-status.toml` — release-train metadata feed for the site.
+
+## Cross-repo context
+
+Static site, independent of the VyOS image build. Sibling corporate web properties live under `sentrium/*` (`next-js-vyos` is the main vyos.io site on Next.js + DatoCMS + Vercel; `community.vyos.net` is the older soupault-based community site). May be consumed by `vyos/amplify-build-status` (also in this chunk) for build-status gating.
+
+## Conventions
+
+- Commit / PR title format: `component: T12345: description` (Phorge task ID mandatory). Enforced by `vyos/.github` reusable workflows where consumed.
+- **Branch model differs:** `main` is the staging branch (auto-deployed to staging.vyos.net); `production` is the production branch.
+- `mergify.yml` adds a `conflicts` label to conflicting PRs (byte-identical to other VyOS repos with this file).
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/community.vyos.net`. Canonical side is **here** (`vyos/community.vyos.net`).
+
+## Notes for future contributors
+
+- This repo's branch model is `main` (staging) → `production` (live), **not** the `current`/`sagitta`/`circinus` train naming used by VyOS image repos.
+- soupault is the build dependency, not Hugo or Jekyll. Install from soupault.app.
+- License: see `LICENSE` (none committed; treat as VyOS-default).
+
+---
+
+This file is mirrored on Confluence: [`vyos/community.vyos.net`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818413601). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,3 @@ Mirror twin: `VyOS-Networks/community.vyos.net`. Canonical side is **here** (`vy
 - This repo's branch model is `main` (staging) → `production` (live), **not** the `current`/`sagitta`/`circinus` train naming used by VyOS image repos.
 - soupault is the build dependency, not Hugo or Jekyll. Install from soupault.app.
 - License: see `LICENSE` (none committed; treat as VyOS-default).
-
----
-
-This file is mirrored on Confluence: [`vyos/community.vyos.net`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818413601). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ make all
 - `plugins/` — soupault Lua plugins.
 - `scripts/` — helper scripts.
 - `soupault.toml` — site config; markdown extensions, strict mode, etc.
-- `amplify.yml` — Amplify build pipeline (likely calls `make all`).
+- `amplify.yml` — Amplify build pipeline (calls `make all`; installs soupault 5.3.0, sass 1.32.8, and Python packages pygithub/jinja2 in preBuild).
 - `release-status.toml` — release-train metadata feed for the site.
 
 ## Cross-repo context


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
