### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+## Project purpose
+
+VyOS community website (community.vyos.net). A static site built by the [soupault](https://soupault.app) static-site generator from HTML pages plus SASS-built CSS. Deployed via AWS Amplify (`amplify.yml` present).
+
+## Tech stack
+
+- Static-site generator: soupault (OCaml).
+- HTML templates under `templates/`, content under `site/`.
+- Sass for stylesheets (`sass/main.sass` → `build/main.css`).
+- Soupault plugins under `plugins/` (Lua).
+- AWS Amplify deploy spec: `amplify.yml`.
+- `release-status.toml` for the per-train release banner data.
+- `.mergify.yml` present (commands-only; no automated rules).
+
+## Build / test / run
+
+```
+# Site
+soupault                    # → build/
+# CSS
+sass -I sass/ sass/main.sass > build/main.css
+# Combined
+make all
+```
+
+## Repository layout
+
+- `templates/` — page skeletons including `main.html`; soupault inserts page content into `div#content`.
+- `site/` — actual page content (Markdown + HTML).
+- `sass/` — SASS sources.
+- `fonts/` — static assets.
+- `plugins/` — soupault Lua plugins.
+- `scripts/` — helper scripts.
+- `soupault.toml` — site config; markdown extensions, strict mode, etc.
+- `amplify.yml` — Amplify build pipeline (calls `make all`; installs soupault 5.3.0, sass 1.32.8, and Python packages pygithub/jinja2 in preBuild).
+- `release-status.toml` — release-train metadata feed for the site.
+
+## Cross-repo context
+
+Static site, independent of the VyOS image build. Sibling corporate web properties live under `sentrium/*` (`next-js-vyos` is the main vyos.io site on Next.js + DatoCMS + Vercel; `community.vyos.net` is the older soupault-based community site). May be consumed by `vyos/amplify-build-status` (also in this chunk) for build-status gating.
+
+## Conventions
+
+- Commit / PR title format: `component: T12345: description` (Phorge task ID mandatory). Enforced by `vyos/.github` reusable workflows where consumed.
+- **Branch model differs:** `main` is the staging branch (auto-deployed to staging.vyos.net); `production` is the production branch.
+- `.mergify.yml` provides Mergify commands (`merge`, `rebase`, `update`, `backport`) but has no automated PR rules.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/community.vyos.net`. Canonical side is **here** (`vyos/community.vyos.net`).
+
+## Notes for future contributors
+
+- This repo's branch model is `main` (staging) → `production` (live), **not** the `current`/`sagitta`/`circinus` train naming used by VyOS image repos.
+- soupault is the build dependency, not Hugo or Jekyll. Install from soupault.app.
+- License: see `LICENSE` (none committed; treat as VyOS-default).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,10 +47,6 @@ Static site, independent of the VyOS image build. Sibling corporate web properti
 - **Branch model differs:** `main` is the staging branch (auto-deployed to staging.vyos.net); `production` is the production branch.
 - `.mergify.yml` provides Mergify commands (`merge`, `rebase`, `update`, `backport`) but has no automated PR rules.
 
-## Mirror relationship
-
-Mirror twin: `VyOS-Networks/community.vyos.net`. Canonical side is **here** (`vyos/community.vyos.net`).
-
 ## Notes for future contributors
 
 - This repo's branch model is `main` (staging) → `production` (live), **not** the `current`/`sagitta`/`circinus` train naming used by VyOS image repos.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project purpose
 
-VyOS community website (community.vyos.net). A static site built by the [soupault](https://soupault.app) static-site generator from HTML pages plus SASS-built CSS. Deployed via AWS Amplify (`amplify.yml` present).
+VyOS community website (community.vyos.net). A static site built by the [soupault](https://soupault.net) static-site generator from HTML pages plus SASS-built CSS. Deployed via AWS Amplify (`amplify.yml` present).
 
 ## Tech stack
 


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
