### PR TITLE
T8809: add extends: mergify, preserve manual-only deviation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,12 @@
-# Mergify configuration — manual commands only, no automated rules.
+extends: mergify
+merge_protections_settings:
+  reporting_method: check-runs
+# Local divergence: manual commands only, no automated rules.
 # Available commands (post in a PR comment):
 #   @Mergifyio merge        — merge the PR
 #   @Mergifyio rebase       — rebase the branch on the base branch
 #   @Mergifyio update       — update the branch (merge base into it)
 #   @Mergifyio backport <branch> — backport to another branch
+# Empty pull_request_rules overrides nothing; central rules from `extends: mergify`
+# (commands_restrictions + Label conflicting pull requests + invalid-title) still apply.
 pull_request_rules: []


### PR DESCRIPTION
Adds `extends: mergify` to inherit central baseline (commands_restrictions + invalid-title rule + Label conflicting pull requests rule) while preserving the local manual-only deviation.

Also adds explicit `merge_protections_settings.reporting_method: check-runs` per [T8925](https://vyos.dev/T8925) (Mergify deprecation deadline 2026-07-31).

Finishes [T8782](https://vyos.dev/T8782) subtask [T8809](https://vyos.dev/T8809).

🤖 Generated by [robots](https://vyos.io)