### PR TITLE
T8943: migrate branch refs main->production (rollout 1c)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ name: CI
 on:
   push:
     branches:
-      - main
       - production
       - amplify
   schedule:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,7 +3,7 @@ name: PR build check
 on:
   pull_request:
     branches:
-      - main
+      - production
 
 jobs:
   build:

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [main]
+    branches: [production]
   workflow_dispatch:
     inputs:
       sync_branch:


### PR DESCRIPTION
Rollout 1c reference migration. Own trunk refs main->production; removed duplicate entry in push trigger (production already present); action-ref to vyos/.github -> production; HIGH-producer pins already swept. Tracking: T8943