### PR TITLE
T8943: retarget main.yml push trigger main->development (rollout 1c)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - development
       - production
       - amplify
   schedule:


### PR DESCRIPTION
## What
Replaces the dead `- main` push-trigger entry in `.github/workflows/main.yml` with `- development` (production reorg renamed main->development; production is now default).

## Why
main.yml deploys by mirroring `github.ref_name` to an AWS Amplify branch (`POST .../branches/${BRANCH}/jobs`). With `main` renamed away, the old trigger was dead; `development` is the renamed integration branch and the Amplify app has a matching `development` branch (operator-confirmed).

## Scope
- `- main` -> `- development` only. `- production` and `- amplify` left unchanged (note: no `amplify` git branch currently exists — pre-existing, out of scope here).

## Review note
CodeRabbit Phase-0 flagged reverting to `main`; dismissed — git `main` no longer exists (renamed), so that would be a dead trigger. Tracking: T8943