### PR TITLE
ci: T8947: point CLA check at vyos-cla-signatures@production (rollout 1c follow-up)

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -14,5 +14,5 @@ on:
 
 jobs:
   call-cla-assistant:
-    uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current
+    uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@production
     secrets: inherit


### PR DESCRIPTION
## What

`cla-check.yml` calls the reusable workflow at `vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current`. Rollout 1c ([IS-503](https://vyos.atlassian.net/browse/IS-503)) made `production` the default branch of `vyos-cla-signatures`, and its `current` branch has since **diverged**:

| Branch | `cla-reusable.yml` writes signatures to |
|--------|------------------------------------------|
| `current` (stale) | `branch: 'current'` |
| `production` (current) | `branch: 'production'` |

So CLA signatures from this repo's PRs were being committed to the stale `current` branch. This flips the ref to `@production`.

## Scope / follow-up

This PR only retargets the reusable-workflow ref. **Reconciling the signatures already accumulated on `vyos-cla-signatures@current` since the rename — and whether to delete that branch — is a separate operator decision** tracked in [IS-504](https://vyos.atlassian.net/browse/IS-504) / T8947.

## Tracking

- Jira: [IS-504](https://vyos.atlassian.net/browse/IS-504) (companion to [IS-503](https://vyos.atlassian.net/browse/IS-503))
- Phorge: T8947 (subtask of T8943)

🤖 Generated by [robots](https://vyos.io)

[IS-503]: https://vyos.atlassian.net/browse/IS-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IS-504]: https://vyos.atlassian.net/browse/IS-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IS-504]: https://vyos.atlassian.net/browse/IS-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IS-503]: https://vyos.atlassian.net/browse/IS-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ