### PR TITLE
T8943: ci: remove dead amplify branch from CI push trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - development
       - production
-      - amplify
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## What

Removes the `amplify` entry from `main.yml`'s `on.push.branches` list. No branch named `amplify` exists in this repository, so the entry is unreachable configuration.

## Why

Completes the CI-trigger cleanup started in #59 (which retargeted `main` → `development` after the default-branch rename, T8943). After this change the trigger list matches the repository's real long-lived branches: `development` + `production`.

## Impact

None at runtime — the removed trigger could never fire. Scheduled (`cron`), `workflow_dispatch`, and `workflow_call` triggers are untouched.

🤖 Generated by [robots](https://vyos.io)