### PR TITLE
fix: remove async from Cookiebot loader to guarantee consent-before-GTM

### DIFF
--- a/soupault.toml
+++ b/soupault.toml
@@ -42,12 +42,18 @@
   selector = "main"
   action = "insert_before"
 
-# Cookiebot consent banner — loaded before GTM so consent state is set
-# before any tracking tags fire.
+# Cookiebot consent banner — must be synchronous (no `async`) so the browser
+# blocks on it before parsing GTM's inline bootstrap script. With `async`,
+# the GTM snippet would execute before Cookiebot sets consent state.
+#
+# `after = "insert-google-tag-manager-head"` controls soupault execution order,
+# not DOM order: GTM widget runs first (prepends GTM to <head>), then this
+# widget runs and prepends Cookiebot — so Cookiebot ends up before GTM in the
+# final HTML.
 [widgets.insert-cookiebot-loader]
   widget = "insert_html"
   html = """
-<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="932cb8b9-5141-4dc9-9018-21fc31a0586f" data-blockingmode="auto" type="text/javascript" async></script>
+<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="932cb8b9-5141-4dc9-9018-21fc31a0586f" data-blockingmode="auto" type="text/javascript"></script>
 """
   selector = "head"
   action = "prepend_child"


### PR DESCRIPTION
## What

Cherry-pick of `6d6a2a3` (already on `development` via #45) onto `production`: removes the `async` attribute from the Cookiebot `uc.js` loader in `soupault.toml` so the browser blocks on Cookiebot before parsing GTM's inline bootstrap.

## Why (live consent bug on vyos.net)

Cookiebot's scan reports **"Prior consent fully enabled: no"** for vyos.net. Verified at runtime on the live site (fresh, no-consent browser): with `async`, the GTM inline bootstrap runs and injects `gtm.js` **before** Cookiebot sets consent state, so GTM tags fire pre-consent — the Google Ads conversion linker writes the **`_gcl_au`** marketing cookie, and GA4/Ads/HubSpot requests fire — all before the visitor consents. Cookiebot's auto-blocking loses the race (`text/plain` blocked scripts = 0).

GCM default-deny, GA4, the Google Ads tag, and the conversion linker all live in the GTM container `GTM-T5VQHRT`, not this repo — so the repo-side fix is the load ordering: making Cookiebot render-blocking (no `async`) lets it initialize + auto-block before GTM runs. The repo's own comment already documents this intent.

## Path to production

This fix has been on `development` since 2026-04-18 but was never promoted. `production` (= live) still serves the `async` version. This is a direct hotfix to `production` rather than a `development`→`production` merge, to avoid dragging the unrelated branch divergence along (handled in a separate sync PR).

## Deploy

Merge → GHA `main.yml` (push trigger) → AWS Amplify → live vyos.net.

## Verify after deploy

⚠️ Removing `async` is the correct repo-side fix, but full elimination of the pre-consent `_gcl_au` also depends on the GTM-container Consent Mode config governing the Ads conversion linker. Re-scan vyos.net (or a fresh no-consent visit) after deploy to confirm `_gcl_au` and the GA/Ads requests no longer fire before consent.

Companion fixes for `vyos.io` (next-js-vyos) and `blog.vyos.io` (HubSpot CMS) are tracked separately.

🤖 Generated by [robots](https://vyos.io)
